### PR TITLE
fix concatenation error for boolean values in packet tracker

### DIFF
--- a/PacketViewer/PacketViewer.lua
+++ b/PacketViewer/PacketViewer.lua
@@ -381,7 +381,9 @@ function track_packet(dir, id, data, modified, injected, blocked)
         for field in fields:filter(filter_settings):filter(boolean._exists .. table.get-{'fn'}):it() do
             local val = field.fn(packet[field.label], packet._raw)
             if val ~= nil then
-                packet['_f_' .. field.label] = ' (' .. val .. ')'
+                if type(val) ~= 'boolean' then
+                    packet['_f_' .. field.label] = ' (' .. val .. ')'
+                end
             end
         end
 


### PR DESCRIPTION
packet tracker was throwing string concatenation errors for boolean values. quick fix.